### PR TITLE
fix: The cpu usage is too high.

### DIFF
--- a/syncer_loki.go
+++ b/syncer_loki.go
@@ -223,6 +223,7 @@ func (syncer *LokiSyncer) Bootstrap(context.Context) {
 					syncer.send()
 					waitChannel.Reset(syncer.maxBatchWaitMs)
 				}
+				time.Sleep(time.Duration(10) * time.Millisecond)
 			}
 		}
 	}()


### PR DESCRIPTION
syncer_loki.go line 221, 
'default' -- 'syncer.buffer.len() >= syncer.maxBatchSize', If the condition is not met, it will fall into an infinite loop.
Add a row of sleep, 'time.Sleep(time.Duration(10) * time.Millisecond)'

![图片](https://user-images.githubusercontent.com/17765320/198839342-3cda57f1-0e1b-4c0f-903b-f12b21a19c71.png)

![图片](https://user-images.githubusercontent.com/17765320/198839330-afd2bd0f-35e1-4f5d-a086-ece3df2ae9da.png)
